### PR TITLE
Add picture to wikihover output

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -54,9 +54,11 @@ chrome.extension.sendMessage({}, function(response) {
 			        	boxShadow: "2px 2px 15px rgba(50,50,50,.75)",
 			        	zIndex: 100
 			        };
+			    // Select article pictures that are taller than 100px
 			    var picture = $(data).find('#bodyContent').find('img').filter(function(index) {
 			    	return $(this).attr('height') > 100;
 			    });
+			    // Display popup with picture
 			    if (picture.attr('src') !== undefined) {
 			    	var new_html = '';
 			    		new_html += '<div id="popup-notification" style="display: flex;">';
@@ -70,6 +72,7 @@ chrome.extension.sendMessage({}, function(response) {
 			    		new_html += '</div>';
 			    	$(new_html).css(cssRules).appendTo('body').fadeIn();
 			    }
+			    // If no picture exists, display text-only popup
 			    else {
 			    	$('<div id="popup-notification" style="padding: 10px;">'+content+'</div>').css(cssRules).appendTo('body').fadeIn();
 			    }

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -56,13 +56,13 @@ chrome.extension.sendMessage({}, function(response) {
 			        };
 			    var picture = $(data).find('.infobox').find('img').attr('src');
 			    var new_html = '';
-			    	new_html += '<div id="popup-notification" style="display: flex; flex-wrap: wrap;">';
-			    	new_html += '<div style="width: calc(60% - 10px); margin-top: 10px; margin-bottom: 10px; padding-left: 10px;">';
+			    	new_html += '<div id="popup-notification" style="display: flex;">';
+			    	new_html += '<div style="margin-top: 10px; margin-bottom: 10px; padding-left: 10px;">';
 			    	new_html += content;
 			    	new_html += '</div>';
-			    	new_html += '<div style="background-image: url(';
+			    	new_html += '<img src=';
 			    	new_html += picture;
-			    	new_html += '); background-size: contain; background-position: left; background-repeat: no-repeat; width: calc(40% - 10px);">';
+			    	new_html += ' style="width: auto; max-height: 500px; margin: 0px; padding: 0px; margin-right: 10px;">';
 			    	new_html += '</div>';
 			    	new_html += '</div>';
 			    $(new_html).css(cssRules).appendTo('body').fadeIn();

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -55,17 +55,23 @@ chrome.extension.sendMessage({}, function(response) {
 			        	zIndex: 100
 			        };
 			    var picture = $(data).find('.infobox').find('img').attr('src');
-			    var new_html = '';
-			    	new_html += '<div id="popup-notification" style="display: flex;">';
-			    	new_html += '<div style="margin-top: 10px; margin-bottom: 10px; padding-left: 10px;">';
-			    	new_html += content;
-			    	new_html += '</div>';
-			    	new_html += '<img src=';
-			    	new_html += picture;
-			    	new_html += ' style="width: auto; max-height: 500px; margin: 0px; padding: 0px; margin-right: 10px;">';
-			    	new_html += '</div>';
-			    	new_html += '</div>';
-			    $(new_html).css(cssRules).appendTo('body').fadeIn();
+			    if (picture.attr('src') !== undefined) {
+			    	var new_html = '';
+			    		new_html += '<div id="popup-notification" style="display: flex;">';
+			    		new_html += '<div style="margin-top: 10px; margin-bottom: 10px; padding-left: 10px; align-self: center;">';
+			    		new_html += content;
+			    		new_html += '</div>';
+			    		new_html += '<img src=';
+			    		new_html += picture;
+			    		new_html += ' style="width: auto; max-height: 500px; margin: 0px; padding: 0px; margin-right: 10px;">';
+			    		new_html += '</div>';
+			    		new_html += '</div>';
+			    	$(new_html).css(cssRules).appendTo('body').fadeIn();
+			    }
+			    else {
+			    	$('<div id="popup-notification" style="padding: 10px;">'+content+'</div>').css(cssRules).appendTo('body').fadeIn();
+			    }
+
 			});
 		}
 	}

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -35,7 +35,7 @@ chrome.extension.sendMessage({}, function(response) {
 		{
 			//Clear the data
 			clearData();
-			//Remove the title attribute    
+			//Remove the title attribute
 			element.removeAttr('title');
 
 			var baseURL = window.location.origin, //Get the URL
@@ -45,18 +45,27 @@ chrome.extension.sendMessage({}, function(response) {
 			$.get(fullURL, function(data) {
 			    var content = $(data).find('#bodyContent').find('p').html(),
 			        cssRules = {
-			        	position: 'fixed', 
-			        	top: 10+"px", 
-			        	left: 10+"px", 
+			        	position: 'fixed',
+			        	top: 10+"px",
+			        	left: 10+"px",
 			        	right: 10+"px",
 			        	maxHeight: 500+"px",
-			        	padding: 1.4+"em",
 			        	background: "#fff",
 			        	boxShadow: "2px 2px 15px rgba(50,50,50,.75)",
 			        	zIndex: 100
 			        };
-
-			    $('<div id="popup-notification">'+content+'</div>').css(cssRules).appendTo('body').fadeIn();
+			    var picture = $(data).find('.infobox').find('img').attr('src');
+			    var new_html = '';
+			    	new_html += '<div id="popup-notification" style="display: flex; flex-wrap: wrap;">';
+			    	new_html += '<div style="width: calc(60% - 10px); margin-top: 10px; margin-bottom: 10px; padding-left: 10px;">';
+			    	new_html += content;
+			    	new_html += '</div>';
+			    	new_html += '<div style="background-image: url(';
+			    	new_html += picture;
+			    	new_html += '); background-size: contain; background-position: left; background-repeat: no-repeat; width: calc(40% - 10px);">';
+			    	new_html += '</div>';
+			    	new_html += '</div>';
+			    $(new_html).css(cssRules).appendTo('body').fadeIn();
 			});
 		}
 	}

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -54,7 +54,9 @@ chrome.extension.sendMessage({}, function(response) {
 			        	boxShadow: "2px 2px 15px rgba(50,50,50,.75)",
 			        	zIndex: 100
 			        };
-			    var picture = $(data).find('.infobox').find('img').attr('src');
+			    var picture = $(data).find('#bodyContent').find('img').filter(function(index) {
+			    	return $(this).attr('height') > 100;
+			    });
 			    if (picture.attr('src') !== undefined) {
 			    	var new_html = '';
 			    		new_html += '<div id="popup-notification" style="display: flex;">';
@@ -62,7 +64,7 @@ chrome.extension.sendMessage({}, function(response) {
 			    		new_html += content;
 			    		new_html += '</div>';
 			    		new_html += '<img src=';
-			    		new_html += picture;
+			    		new_html += picture.attr('src');
 			    		new_html += ' style="width: auto; max-height: 500px; margin: 0px; padding: 0px; margin-right: 10px;">';
 			    		new_html += '</div>';
 			    		new_html += '</div>';


### PR DESCRIPTION
Hi ellenbrook, I really enjoy using your extension Wikihover, but I often found myself wishing that there was a picture along with the text.  I added a bit of code to the inject.js file to achieve this.  It only shows pictures that are taller than 100px (to avoid displaying the little icons that accompany alert messages), and if there are no pictures that match the criteria the output will be identical to how it was before I added the changes.  This is my first attempt at contributing to an open-source project so forgive me if I'm going about this the wrong way, but I wanted to share the changes with you in case it was something you were interested in implementing.

Thanks!
Wilding
